### PR TITLE
add in code.co_posonlyargcount to get nibbler working with python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "3.7"
+  - "3.8"
 cache:
   pip: true
 install:

--- a/nibbler/extension/constantize_globals.py
+++ b/nibbler/extension/constantize_globals.py
@@ -45,6 +45,7 @@ def constantize_globals(code: CodeType, context: Context) -> CodeType:
 
     return CodeType(
         code.co_argcount,
+        code.co_posonlyargcount,
         code.co_kwonlyargcount,
         code.co_nlocals,
         code.co_stacksize,

--- a/nibbler/extension/global_to_fast.py
+++ b/nibbler/extension/global_to_fast.py
@@ -40,6 +40,7 @@ def global_to_fast(code: CodeType, context: Context) -> CodeType:
 
     return CodeType(
         code.co_argcount,
+        code.co_posonlyargcount,
         code.co_kwonlyargcount,
         code.co_nlocals,
         code.co_stacksize,

--- a/nibbler/extension/inline.py
+++ b/nibbler/extension/inline.py
@@ -161,6 +161,7 @@ def inline(code: CodeType, context: Context) -> CodeType:
 
     return CodeType(
         code.co_argcount,
+        code.co_posonlyargcount,
         code.co_kwonlyargcount,
         len(varnames),
         code.co_stacksize,

--- a/nibbler/extension/map_source.py
+++ b/nibbler/extension/map_source.py
@@ -25,6 +25,7 @@ def map_source(code: CodeType, context: Context) -> CodeType:
 
     wrapped_const_code = CodeType(
         code.co_argcount,
+        code.co_posonlyargcount,
         code.co_kwonlyargcount,
         code.co_nlocals,
         code.co_stacksize,
@@ -86,6 +87,7 @@ def map_source(code: CodeType, context: Context) -> CodeType:
 
     return CodeType(
         code.co_argcount,
+        code.co_posonlyargcount,
         code.co_kwonlyargcount,
         code.co_nlocals,
         code.co_stacksize,

--- a/nibbler/extension/peephole.py
+++ b/nibbler/extension/peephole.py
@@ -20,6 +20,7 @@ def peephole(code: CodeType, context: Context) -> CodeType:
     )
     return CodeType(
         code.co_argcount,
+        code.co_posonlyargcount,
         code.co_kwonlyargcount,
         code.co_nlocals,
         code.co_stacksize,

--- a/nibbler/extension/precompute_conditionals.py
+++ b/nibbler/extension/precompute_conditionals.py
@@ -76,6 +76,7 @@ def precompute_conditionals(code: CodeType, context: Context) -> CodeType:
 
     return CodeType(
         code.co_argcount,
+        code.co_posonlyargcount,
         code.co_kwonlyargcount,
         code.co_nlocals,
         code.co_stacksize,


### PR DESCRIPTION
made a quick fix to the nibbler extension files to allow for compatibility between this great library and python 3.8